### PR TITLE
Improve documentation and type relationships

### DIFF
--- a/src/main/java/mx/kenzie/maze/Direction.java
+++ b/src/main/java/mx/kenzie/maze/Direction.java
@@ -2,6 +2,9 @@ package mx.kenzie.maze;
 
 import mx.kenzie.maze.random.Seed;
 
+/**
+ * A cardinal direction in two dimensions. May be applied to a {@link Point} to move the point in that direction.
+ * */
 public enum Direction implements Transformation {
     NORTH(0, -1), EAST(1, 0), SOUTH(0, 1), WEST(-1, 0);
     private static final Direction[] values = values();

--- a/src/main/java/mx/kenzie/maze/DrawingPath.java
+++ b/src/main/java/mx/kenzie/maze/DrawingPath.java
@@ -3,6 +3,9 @@ package mx.kenzie.maze;
 import java.util.Collection;
 import java.util.LinkedList;
 
+/**
+ * A modifiable path of points.
+ * */
 public class DrawingPath extends LinkedList<Point> implements Path {
 
     public DrawingPath() {

--- a/src/main/java/mx/kenzie/maze/FixedPath.java
+++ b/src/main/java/mx/kenzie/maze/FixedPath.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * An unmodifiable path of points.
+ * */
 public record FixedPath(Point... points) implements Path {
 
     @Override

--- a/src/main/java/mx/kenzie/maze/Maze.java
+++ b/src/main/java/mx/kenzie/maze/Maze.java
@@ -5,6 +5,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
+/**
+ * A two-dimensional maze.
+ * */
 public record Maze(byte[][] layout, int length, int width) implements Printed, Path {
 
     public Maze(int length, int width) {

--- a/src/main/java/mx/kenzie/maze/Path.java
+++ b/src/main/java/mx/kenzie/maze/Path.java
@@ -2,24 +2,54 @@ package mx.kenzie.maze;
 
 import java.util.Collection;
 
+/**
+ * A path through a maze, i.e., a sequence of points.
+ * */
 public interface Path extends Iterable<Point> {
 
+    /**
+     * @return A path that is this path followed by the other path.
+     * */
     Path union(Path other);
 
+    /**
+     * @return A path that is all points of this path that are included in the other path.
+     * */
     Path intersect(Path other);
 
+    /**
+     * Cuts this path into the given {@link Maze}, removing walls.
+     * */
     void cut(Maze maze);
 
+    /**
+     * Cuts this path into the given {@link Maze}, setting all points to the given {@link State}.
+     * */
     void cut(Maze maze, State state);
 
+    /**
+     * @return The last point in this path.
+     * */
     Point last();
 
+    /**
+     * @return The first point in this path.
+     * */
     Point first();
 
+    /**
+     * @return All points in this path.
+     * */
     Collection<Point> collect();
 
+    /**
+     * @return Whether this path contains the given point.
+     * */
     boolean contains(Point point);
 
+    /**
+     * @return The number of points in this path.
+     * */
     int length();
 
 }

--- a/src/main/java/mx/kenzie/maze/Point.java
+++ b/src/main/java/mx/kenzie/maze/Point.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
+/**
+ * A 2D lattice point, representing either a wall cell or a path cell.
+ * */
 public record Point(int x, int y) implements Path {
 
     public boolean isNextTo(Point point) {

--- a/src/main/java/mx/kenzie/maze/Printed.java
+++ b/src/main/java/mx/kenzie/maze/Printed.java
@@ -5,14 +5,7 @@ import java.io.PrintStream;
 /**
  * Something that can be printed out.
  */
-public interface Printed extends Iterable<Point> {
+public interface Printed {
 
     void print(PrintStream stream);
-
-    int length();
-
-    int width();
-
-    State get(Point point);
-
 }

--- a/src/main/java/mx/kenzie/maze/Printer.java
+++ b/src/main/java/mx/kenzie/maze/Printer.java
@@ -6,13 +6,13 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public record Printer(Printed source, BufferedImage image, int startX, int startY) {
+public record Printer(Maze source, BufferedImage image, int startX, int startY) {
 
-    public Printer(Printed source) {
+    public Printer(Maze source) {
         this(source, new BufferedImage(source.width(), source.length(), BufferedImage.TYPE_INT_ARGB));
     }
 
-    public Printer(Printed source, BufferedImage image) {
+    public Printer(Maze source, BufferedImage image) {
         this(source, image, 0, 0);
     }
 

--- a/src/main/java/mx/kenzie/maze/State.java
+++ b/src/main/java/mx/kenzie/maze/State.java
@@ -28,25 +28,4 @@ public enum State implements Printed {
             default -> stream.print('-');
         }
     }
-
-    @Override
-    public int length() {
-        return 0;
-    }
-
-    @Override
-    public int width() {
-        return 0;
-    }
-
-    @Override
-    public State get(Point point) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Iterator<Point> iterator() {
-        return Collections.emptyIterator();
-    }
-
 }

--- a/src/main/java/mx/kenzie/maze/Transformation.java
+++ b/src/main/java/mx/kenzie/maze/Transformation.java
@@ -1,11 +1,11 @@
 package mx.kenzie.maze;
 
+import java.util.function.UnaryOperator;
+
 /**
  * An operation that, when applied to a point, yields another point, such as applying a vector or a rotation.
  */
 @FunctionalInterface
-public interface Transformation {
-
-    Point apply(Point point);
+public interface Transformation extends UnaryOperator<Point> {
 
 }

--- a/src/main/java/mx/kenzie/maze/generator/Generator.java
+++ b/src/main/java/mx/kenzie/maze/generator/Generator.java
@@ -31,6 +31,10 @@ public interface Generator {
         return correct;
     }
 
+    /**
+     * @return A random direction to move in from the given point that is within the bounds of the maze, or null if no such direction exists.
+     * Moving two steps in this direction will be within the bounds of the maze, but the endpoint may be a wall.
+     * */
     default Direction nextPoint(Point current) {
         final Direction[] directions = Direction.randomOrder(this.seed());
         for (Direction direction : directions) {
@@ -88,6 +92,9 @@ public interface Generator {
         return path;
     }
 
+    /**
+     * Draws and cuts a path between two {@link Point}s by making two random paths and then joining them with {@link Generator#join(Point, Point)}. This modifies the maze.
+     * */
     default Path drawPath(Point from, Point to) {
         final Point end = to.correct();
         this.drawDot(to);
@@ -99,6 +106,10 @@ public interface Generator {
         return path.union(reverse).union(this.join(end, to));
     }
 
+    /**
+     * Draws a path using a random walk which starts at the given {@link Point} and ends either when
+     * it hits a wall or when it hits an existing part of the maze. This does not modify the maze.
+     * */
     default Path drawPath(Point from) {
         final Point start = from.correct();
         this.maze().set(start, State.WALL);
@@ -118,6 +129,10 @@ public interface Generator {
         return path;
     }
 
+    /**
+     * Draws and cuts a random path into the {@link Maze}. This does not modify the maze.
+     * @see #drawPath(Point)
+     * */
     default Path cutPath(Point from) {
         final Path path = this.drawPath(from);
         path.cut(this.maze());

--- a/src/main/java/mx/kenzie/maze/random/Seed.java
+++ b/src/main/java/mx/kenzie/maze/random/Seed.java
@@ -20,6 +20,9 @@ public interface Seed {
         return of(new Random());
     }
 
+    /**
+     * @return A random integer in the range [0, <i>range</i>[.
+     * */
     int random(int x, int y, int range);
 
     default int random(int range) {


### PR DESCRIPTION
This PR documents several methods and classes that were previously missing documentation. Additionally, it makes the following changes to the type model:

1. Some behaviour from `Printed` that was exclusive to `Maze` and failed at runtime for other `Printed` types has been moved to `Maze`. Consequently, the `Printer` class has been adapted to print `Maze`s instead of `Printed`s.
2. The `Transformation` functional interface, which had a signature identical to `UnaryOperator<Point>`, now extends `UnaryOperator<Point>`.
