### PR TITLE
Back-tracking generator.

### DIFF
--- a/src/main/java/mx/kenzie/maze/Point.java
+++ b/src/main/java/mx/kenzie/maze/Point.java
@@ -1,8 +1,6 @@
 package mx.kenzie.maze;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.*;
 
 /**
  * A 2D lattice point, representing either a wall cell or a path cell.
@@ -75,4 +73,16 @@ public record Point(int x, int y) implements Path {
         return Collections.singleton(this).iterator();
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final Point point = (Point) o;
+        return x == point.x && y == point.y;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y);
+    }
 }

--- a/src/main/java/mx/kenzie/maze/generator/BacktrackingGenerator.java
+++ b/src/main/java/mx/kenzie/maze/generator/BacktrackingGenerator.java
@@ -1,0 +1,100 @@
+package mx.kenzie.maze.generator;
+
+import mx.kenzie.maze.Point;
+import mx.kenzie.maze.*;
+import mx.kenzie.maze.random.Seed;
+
+import java.util.List;
+import java.util.*;
+
+/**
+ * An incredibly simple maze generator that uses a backtracking algorithm to
+ * fill the maze with a single path. This has the interesting property that there
+ * will always be exactly one path between any two points in the maze.
+ * <p>
+ * This generator generally performs well even for large mazes, as long as it does not run
+ * out of memory.
+ *
+ * @param maze The source to draw on
+ * @param seed The random provider for the source
+ */
+public record BacktrackingGenerator(Maze maze, Seed seed) implements Generator {
+
+    @Override
+    public Path fill() {
+        final Set<Point> visited = new HashSet<>();
+        final Map<Point, Point> discoveryMap = new HashMap<>();
+        final ArrayDeque<Point> stack = new ArrayDeque<>();
+
+        final Point startingCell = new Point(0, 0);
+        discoveryMap.put(startingCell, null);
+        stack.push(startingCell);
+
+        while (!stack.isEmpty()) {
+            final Point currentCell = stack.peek();
+            visited.add(currentCell);
+
+            final List<Point> neighbours = new ArrayList<>();
+            for (final Direction direction : Direction.randomOrder(seed)) {
+                final Point neighbour = direction.apply(direction.apply(currentCell));
+
+                final int x = neighbour.x();
+                final int y = neighbour.y();
+                if (x < 0 || y < 0 || x >= this.maze().length() || y >= this.maze().width()) continue;
+
+                if (visited.contains(neighbour)) continue;
+                neighbours.add(neighbour);
+            }
+
+            if (neighbours.isEmpty()) {
+                stack.pop();
+            } else {
+                final Point nextCell = neighbours.get(seed.random(neighbours.size()));
+                assert nextCell.x() == currentCell.x() || nextCell.y() == currentCell.y();
+                join(currentCell, nextCell).cut(maze, State.EMPTY);
+                nextCell.cut(maze, State.EMPTY);
+                discoveryMap.put(nextCell, currentCell);
+                stack.push(nextCell);
+            }
+        }
+
+        return getPathTo(new Point(maze.length() - 1, maze.width() - 1), discoveryMap);
+    }
+
+    private DrawingPath getPathTo(final Point target, final Map<Point, Point> discoveryMap) {
+        final DrawingPath path = new DrawingPath();
+        path.add(target);
+
+        Point current = discoveryMap.get(target);
+        if (current == null) return null;
+
+        while (current != null) {
+            final int x = current.x();
+            final int y = current.y();
+
+            final int lastX = path.last().x();
+            final int lastY = path.last().y();
+            final int dx = x - lastX;
+            final int dy = y - lastY;
+            final int sx = Integer.signum(dx);
+            final int sy = Integer.signum(dy);
+            for (int i = lastX + sx;; i += sx) {
+                path.add(new Point(i, y));
+                if (i == x) break;
+            }
+            for (int i = lastY + sy;; i += sy) {
+                path.add(new Point(x, i));
+                if (i == y) break;
+            }
+
+            current = discoveryMap.get(current);
+        }
+
+        return path;
+    }
+
+    @Override
+    public void scribble() {
+        this.fill();
+    }
+}

--- a/src/test/java/mx/kenzie/maze/ExampleBacktrackingMaze.java
+++ b/src/test/java/mx/kenzie/maze/ExampleBacktrackingMaze.java
@@ -1,0 +1,29 @@
+package mx.kenzie.maze;
+
+import mx.kenzie.maze.generator.*;
+import mx.kenzie.maze.random.Seed;
+
+import java.io.*;
+
+public class ExampleBacktrackingMaze {
+    public static void main(final String... args) throws IOException {
+        final int length = 1025, width = 1025;
+        final Maze maze = new Maze(length, width);
+        final Generator generator = new BacktrackingGenerator(maze, Seed.of("test :)".hashCode()));
+        final Point start, end;
+        start = new Point(0, 0);
+        end = new Point(length - 1, width - 1);
+        final Path correct = generator.fill();
+        correct.cut(maze, State.CORRECT);
+        start.cut(maze, State.START);
+        end.cut(maze, State.END);
+
+        final Printer printer = new Printer(maze);
+        printer.draw();
+
+        final File file = new File("maze.png");
+        try (final OutputStream stream = new FileOutputStream(file)) {
+            printer.print(stream);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a generator that utilises a back-tracking depth-first search to generate the maze.
The benefit of this generator is that it always runs in `O(M*N)` time for an M-by-N maze, which
means it drastically outperforms existing implementations on large mazes, at the cost of memory efficiency.

The PR also adds the `Point#equals()` and `Point#hashCode()` methods, both because they are good to
have and because the DFS implementation depends on them :)

![A giant maze](https://github.com/Moderocky/Maze/assets/52505120/7f90712c-9a3e-41b8-bf2d-97c35bc8cfee)
*Fig. 1: A giant maze.*